### PR TITLE
Use ServerEngine::Daemon#main directory

### DIFF
--- a/lib/griffin/engine.rb
+++ b/lib/griffin/engine.rb
@@ -13,7 +13,7 @@ module Griffin
 
       if cluster
         Griffin.logger.info("Griffin v#{Griffin::VERSION} starts as cluster mode")
-        ServerEngine.create(Griffin::Engine::Server, Griffin::Engine::Worker, config).run
+        ServerEngine.create(Griffin::Engine::Server, Griffin::Engine::Worker, config).main
       else
         Griffin.logger.info("Griffin v#{Griffin::VERSION} starts as single mode")
         Griffin::Engine::Single.create(config).run


### PR DESCRIPTION
Error reporting libraries (e.g. sentry-raven) decide an application
exits with Kernel.#exit as an error(so sending an error report) even
if `exit 0`. To use ServerEngine::Daemon#main, griffin does not exit
with Kernel.#exit

(before) giriffin exits with  Kernel.#exit
```ruby
begin
  Griffin::Server.run
rescue SystemExit => e
  p e # #<SystemExit: exit>
end
```
ref: https://github.com/treasure-data/serverengine/blob/a005f3535affaa5b15d1e66486d9349443398dd2/lib/serverengine/daemon.rb#L68


