### PR TITLE
server can delegate shutdown_timeout option to grpc_kit

### DIFF
--- a/lib/griffin/server.rb
+++ b/lib/griffin/server.rb
@@ -41,6 +41,7 @@ module Griffin
     # @param min_connection_size [Integer] Maximun connection of TCP
     # @param max_connection_size [Integer] Minimum connection of TCP
     # @param interceptors [Array<GrpcKit::GRPC::ServerInterceptor>] list of interceptors
+    # @param shutdown_timeout [Integer] Timeout for server shutdown in seconds
     # @param settings [Array<DS9::Settings,Integer>] list of HTTP2-Settings headers
     # @param max_receive_message_size [Integer, nil] Specify the default maximum size of inbound message in bytes. Default to 4MB.
     # @param max_send_message_size [Integer, nil] Specify the default maximum size of outbound message in bytes. Default to 4MB.


### PR DESCRIPTION
I hope to control grpc_kit timeout on development environment.
So I add ‘shutdown_timeout’ parameter into initialize method to delegate it. 

shutdown_timeout: “30" is same value as grpc_kit.
I considered the possibility of not using default values on the Griffin side, but I set it as well as the other parameters.